### PR TITLE
Changed Persist to correct value

### DIFF
--- a/TFS/New-TFSCredential.ps1
+++ b/TFS/New-TFSCredential.ps1
@@ -21,7 +21,7 @@ function New-TFSCredential {
     if (($global:tfs.root_url -eq '') -or ($global:tfs.root_url -eq $null)) { throw 'You must set $global:tfs.root_url in order to store credentials' }
 
     Write-Verbose "Storing credential for target '$($global:tfs.root_url)'"
-    New-StoredCredential -Target $global:tfs.root_url -UserName $Credential.UserName -Password $Credential.GetNetworkCredential().Password -Persist LOCAL_MACHINE | Out-Null
+    New-StoredCredential -Target $global:tfs.root_url -UserName $Credential.UserName -Password $Credential.GetNetworkCredential().Password -Persist LocalMachine | Out-Null
 
     return $Credential
 }


### PR DESCRIPTION
Changed -Persist LOCAL_MACHINE to -Persist LocalMachine

This resolves errors received when the the TFS module tries to create new credentials:

https://github.com/davotronic5000/PowerShell_Credential_Manager/issues/15